### PR TITLE
Chore/add db migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ include scripts/make_rules/golang.mk
 include scripts/make_rules/tools.mk
 include scripts/make_rules/docker.mk
 include scripts/make_rules/swagger.mk
+include scripts/make_rules/mysql.mk
 
 # Usages
 define USAGE_OPTIONS

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Golang, Gin, gRPC, MySQL, GORM
     - [Build Local Executable](#build-local-executable)
     - [Build Docker Image](#build-docker-image)
     - [Deploy Locally with Docker Compose for Development](#deploy-locally-with-docker-compose-for-development)
-    - [Learn More about Usage of GNU make](#learn-more-about-usage-of-gnu-make)
+    - [MySQL Database Schema Migration](#mysql-database-schema-migration)
+      - [Quick Example](#quick-example)
+      - [Use Custom MySQL Config](#use-custom-mysql-config)
+    - [Show help message for make](#show-help-message-for-make)
   - [API Doc](#api-doc)
     - [RESTful API](#restful-api)
     - [gRPC API](#grpc-api)
@@ -52,7 +55,53 @@ make docker.compose.up
 make docker.compose.down
 ```
 
-### Learn More about Usage of GNU make
+### MySQL Database Schema Migration
+Some handy wrappings are provided in Make Phonies with prefix `mysql.migrate.*`.
+
+#### Quick Example
+Below is a quick example for creating and applying a migration. For more details, see [mysql.mk](./scripts/make_rules/mysql.mk)
+```bash
+# create migration for adding table foo
+$ make mysql.migrate.create.add_table_foo
+=======> MySQL: ensuring migrations directory exists
+=======> MySQL: creating new MySQL migration: foo
+/some/dir/timer_apiserver/database/migrations/20210930054712_foo.up.sql
+/some/dir/timer_apiserver/database/migrations/20210930054712_foo.down.sql
+
+# fill in desired SQL statements into .sql files newly generated above
+
+# apply up migrations
+$ make mysql.migrate.up
+=======> MySQL: applying all up migrations
+20210930054712/u add_table_foo (33.492584ms)
+
+# now table foo is created
+
+# to undo it, apply down migrations
+$ make mysql.migrate.down
+=======> MySQL: applying all down migrations
+Are you sure you want to apply all down migrations? [y/N]
+y
+Applying all down migrations
+20210930054712/d add_table_foo (21.437875ms)
+
+# now table foo is gone
+```
+#### Use Custom MySQL Config
+By default, dummy configs listed in [mysql.mk](./scripts/make_rules/mysql.mk) are used to connect to MySQL.
+```make
+MYSQL_USER ?= root
+MYSQL_PWD ?= root
+MYSQL_HOST ?= localhost
+MYSQL_PORT ?= 3306
+MYSQL_DB ?= test
+```
+To use custom config, specify environment variables when invoking Make
+```bash
+MYSQL_PORT=3307 make mysql.migrate.up
+```
+
+### Show help message for make
 ```bash
 make help
 ```

--- a/database/migrations/20210930050139_add_table_timer.down.sql
+++ b/database/migrations/20210930050139_add_table_timer.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `timer`;

--- a/database/migrations/20210930050139_add_table_timer.up.sql
+++ b/database/migrations/20210930050139_add_table_timer.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `timer` (
+    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `deleted_at` DATETIME DEFAULT NULL,
+    `name` VARCHAR(255) NOT NULL,
+    `trigger_at` DATETIME NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx_timer_deleted_at` (`deleted_at`),
+    KEY `idx_timer_trigger_at` (`trigger_at`),
+    CONSTRAINT `uniq_timer_name` UNIQUE (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4;

--- a/scripts/make_rules/mysql.mk
+++ b/scripts/make_rules/mysql.mk
@@ -1,0 +1,72 @@
+MYSQL_USER ?= root
+MYSQL_PWD ?= root
+MYSQL_HOST ?= localhost
+MYSQL_PORT ?= 3306
+MYSQL_DB ?= test
+
+MYSQL_DSN = "mysql://$(MYSQL_USER):$(MYSQL_PWD)@tcp($(MYSQL_HOST):$(MYSQL_PORT))/$(MYSQL_DB)"
+MYSQL_MIGRATION_DIR = $(PROJECT_ROOT)/database/migrations
+MYSQL_MIGRATION_SRC = "file://$(MYSQL_MIGRATION_DIR)"
+
+MYSQL_MK_PREFIX := "MySQL:"
+
+.PHONY: mysql.migrate.mkdir
+mysql.migrate.mkdir:
+	@echo "=======> $(MYSQL_MK_PREFIX) ensuring migrations directory exists"
+	@mkdir -p $(MYSQL_MIGRATION_DIR)
+
+# Below provides handy wrapping for golang-migrate cli
+# For detailed usage of golang-migrate cli, see https://github.com/golang-migrate/migrate/tree/master/cmd/migrate#usage
+
+# create [-ext E] [-dir D] [-seq] [-digits N] [-format] NAME
+#                Create a set of timestamped up/down migrations titled NAME, in directory D with extension E.
+#                Use -seq option to generate sequential up/down migrations with N digits.
+#                Use -format option to specify a Go time format string.
+.PHONY: mysql.migrate.create.%
+mysql.migrate.create.%: mysql.migrate.mkdir tools.verify.go-migrate
+	@echo "=======> $(MYSQL_MK_PREFIX) creating new MySQL migration: $*"
+	@migrate -database $(MYSQL_DSN) create -ext .sql -dir $(MYSQL_MIGRATION_DIR) $*
+
+# goto V       Migrate to version V
+.PHONY: mysql.migrate.goto.%
+mysql.migrate.goto.%: mysql.migrate.mkdir tools.verify.go-migrate
+	@echo "=======> $(MYSQL_MK_PREFIX) migrating to version $*"
+	@migrate -database $(MYSQL_DSN) -source $(MYSQL_MIGRATION_SRC) goto $*
+
+# up [N]       Apply all or N up migrations
+.PHONY: mysql.migrate.up
+mysql.migrate.up: mysql.migrate.mkdir tools.verify.go-migrate
+	@echo "=======> $(MYSQL_MK_PREFIX) applying all up migrations"
+	@migrate -database $(MYSQL_DSN) -source $(MYSQL_MIGRATION_SRC) up
+.PHONY: mysql.migrate.up.%
+mysql.migrate.up.%: mysql.migrate.mkdir tools.verify.go-migrate
+	@echo "=======> $(MYSQL_MK_PREFIX) applying $* up migrations"
+	@migrate -database $(MYSQL_DSN) -source $(MYSQL_MIGRATION_SRC) up $*
+
+# down [N]     Apply all or N down migrations
+.PHONY: mysql.migrate.down
+mysql.migrate.down: mysql.migrate.mkdir tools.verify.go-migrate
+	@echo "=======> $(MYSQL_MK_PREFIX) applying all down migrations"
+	@migrate -database $(MYSQL_DSN) -source $(MYSQL_MIGRATION_SRC) down
+.PHONY: mysql.migrate.down.%
+mysql.migrate.down.%: mysql.migrate.mkdir tools.verify.go-migrate
+	@echo "=======> $(MYSQL_MK_PREFIX) applying $* down migrations"
+	@migrate -database $(MYSQL_DSN) -source $(MYSQL_MIGRATION_SRC) down $*
+	
+# drop         Drop everything inside database
+.PHONY: mysql.migrate.drop
+mysql.migrate.drop: mysql.migrate.mkdir tools.verify.go-migrate
+	@echo "=======> $(MYSQL_MK_PREFIX) [!!DANGREROUS!!] dropping entire database schema"
+	@migrate -database $(MYSQL_DSN) -source $(MYSQL_MIGRATION_SRC) drop 
+
+# force V      Set version V but don't run migration (ignores dirty state)
+.PHONY: mysql.migrate.force.%
+mysql.migrate.force.%: mysql.migrate.mkdir tools.verify.go-migrate
+	@echo "=======> $(MYSQL_MK_PREFIX) forcing migration version to $* without actually running migrations"
+	@migrate -database $(MYSQL_DSN) -source $(MYSQL_MIGRATION_SRC) force $*
+
+# version      Print current migration version
+.PHONY: mysql.migrate.version
+mysql.migrate.version: mysql.migrate.mkdir tools.verify.go-migrate
+	@echo "=======> $(MYSQL_MK_PREFIX) printting current migration version"
+	@migrate -database $(MYSQL_DSN) -source $(MYSQL_MIGRATION_SRC) version

--- a/scripts/make_rules/tools.mk
+++ b/scripts/make_rules/tools.mk
@@ -12,4 +12,8 @@ tools.install.golangci-lint:
 
 .PHONY: tools.install.swagger
 tools.install.swagger:
-	$(GO) install github.com/go-swagger/go-swagger/cmd/swagger@latest
+	@$(GO) install github.com/go-swagger/go-swagger/cmd/swagger@latest
+
+.PHONY: tools.install.go-migrate
+tools.install.go-migrate:
+	@$(GO) install -tags 'mysql' github.com/golang-migrate/migrate/v4/cmd/migrate@latest


### PR DESCRIPTION
- pick [golang-migrate](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate#usage) as the cli tool to manage migrations
- add makefile support for golang-migrate
- add instructions for MySQL migration in README