### PR TITLE
🐎 ci(circleci): update circleci image to golangci/golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build: 
     docker:
-      - image: golang:1.17.1-bullseye
+      - image: golangci/golangci-lint
     steps:
       - checkout
       - run:


### PR DESCRIPTION
so as to avoid installing golangci-lint everytime when running circleci pipeline