### PR TITLE
Feat(resource)/use multiple unique index

### DIFF
--- a/database/migrations/20210930050139_add_table_timer.up.sql
+++ b/database/migrations/20210930050139_add_table_timer.up.sql
@@ -3,10 +3,10 @@ CREATE TABLE IF NOT EXISTS `timer` (
     `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `deleted_at` DATETIME DEFAULT NULL,
+    `alive` BOOLEAN DEFAULT TRUE,
     `name` VARCHAR(255) NOT NULL,
     `trigger_at` DATETIME NOT NULL,
     PRIMARY KEY (`id`),
-    KEY `idx_timer_deleted_at` (`deleted_at`),
-    KEY `idx_timer_trigger_at` (`trigger_at`),
-    CONSTRAINT `uniq_timer_name` UNIQUE (`name`)
+    KEY `idx_trigger_at` (`trigger_at`),
+    CONSTRAINT `uniq_name_alive` UNIQUE (`name`, `alive`)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4;

--- a/internal/resource/v1/model/model.go
+++ b/internal/resource/v1/model/model.go
@@ -2,15 +2,12 @@ package model
 
 import (
 	"time"
-
-	"gorm.io/gorm"
 )
 
 // Model is the slightly-updated version of gorm.Model
 // It will be managed automatically by gorm
 type Model struct {
-	ID        uint           `json:"-" gorm:"primarykey"`
-	CreatedAt time.Time      `json:"createdAt"`
-	UpdatedAt time.Time      `json:"-"`
-	DeletedAt gorm.DeletedAt `json:"-" gorm:"index"`
+	ID        uint      `json:"-" gorm:"primarykey"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"-"`
 }

--- a/internal/resource/v1/model/timer.go
+++ b/internal/resource/v1/model/timer.go
@@ -4,17 +4,20 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
+	"gorm.io/gorm"
 )
 
 // TimerCore contains fields that can be specified directly via APIs
 type TimerCore struct {
-	Name      string    `json:"name" gorm:"unique" validate:"required"`
-	TriggerAt time.Time `json:"triggerAt" gorm:"index" validate:"required,gte=time.Now().Add(time.Minute)"`
+	Name      string    `json:"name" gorm:"index:uniq_name_alive,unique,priority:1" validate:"required"`
+	TriggerAt time.Time `json:"triggerAt" gorm:"index:idx_trigger_at" validate:"required,gte=time.Now().Add(time.Minute)"`
 }
 
 type Timer struct {
 	Model
 	TimerCore
+	Alive     bool           `json:"-" gorm:"index:uniq_name_alive,unique,priority:2"`
+	DeletedAt gorm.DeletedAt `json:"-"`
 }
 
 func (t *Timer) TableName() string {

--- a/internal/resource/v1/store/mysql/timer/create.go
+++ b/internal/resource/v1/store/mysql/timer/create.go
@@ -14,6 +14,7 @@ var dbCreateFunc = func(db *gorm.DB, value interface{}) error {
 }
 
 func (s *TimerStore) Create(timer *model.Timer) error {
+	timer.Alive = true
 	err := dbCreateFunc(s.DB, timer)
 	if err == nil {
 		return nil

--- a/internal/resource/v1/store/mysql/timer/delete.go
+++ b/internal/resource/v1/store/mysql/timer/delete.go
@@ -1,28 +1,40 @@
 package timer
 
 import (
+	"errors"
+
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 
+	pkgerr "github.com/josephzxy/timer_apiserver/internal/pkg/err"
 	"github.com/josephzxy/timer_apiserver/internal/resource/v1/model"
 )
 
 var dbDeleteByNameFunc = func(db *gorm.DB, name string) error {
-	return db.Where("name = ?", name).Delete(&model.Timer{}).Error
-}
-
-var tsGetByNameFunc = func(ts *TimerStore, name string) (*model.Timer, error) {
-	return ts.GetByName(name)
+	return db.Transaction(func(tx *gorm.DB) error {
+		var timer model.Timer
+		if err := tx.Where("name = ?", name).First(&timer).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("name = ?", name).Delete(&timer).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec("UPDATE `timer` SET `alive`=NULL WHERE `id`= ?", timer.ID).Error; err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func (s *TimerStore) DeleteByName(name string) error {
-	_, err := tsGetByNameFunc(s, name)
-	if err != nil {
-		return err
+	err := dbDeleteByNameFunc(s.DB, name)
+	if err == nil {
+		return nil
 	}
+	zap.S().Errorw("failed to delete timer", "err", err)
 
-	delErr := dbDeleteByNameFunc(s.DB, name)
-	if delErr != nil {
-		return delErr
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return pkgerr.New(pkgerr.ErrTimerNotFound, "")
 	}
-	return nil
+	return err
 }


### PR DESCRIPTION
## Problem solved in this PR
Timers are designed to be uniquely identified by their names. However, creating a new timer after deleting the one with the same name will fail due to the MySQL table schema where a unique constraint is applied to the field `name` while soft deletion is enabled. 

To solve it, we introduce a new boolean column `alive` that is default to `true` on creating timers while set to `null` on deleting. For each timer, `alive` will be `non-null` if `deleted_at` is `null`, and `alive` will be `null` if `deleted_at` is `non-null` so as to ensure there will be only one non-deleted timer and possibly multiple deleted timers for a name.