### PR TITLE
🐳 chore(makefile): separate generate from serve for swagger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ docker: docker.build
 
 ## swagger: Generate swagger doc for RESTful API and launch a local HTTP server to display
 .PHONY: swagger
-swagger: swagger.serve
+swagger: swagger.generate swagger.serve
 
 ## clean: Remove temporary files generated during building
 .PHONY: clean

--- a/scripts/make_rules/swagger.mk
+++ b/scripts/make_rules/swagger.mk
@@ -12,6 +12,6 @@ swagger.generate: tools.verify.swagger
 	@swagger generate spec -o $(SWGR_SPEC_FILE)
 
 .PHONY: swagger.serve
-swagger.serve: swagger.generate
+swagger.serve: tools.verify.swagger
 	@echo "=======> $(SWGR_MK_PREFIX) serving swagger specification at http://localhost:$(SWGR_SRV_PORT)/docs"
 	@swagger serve -F=redoc --port $(SWGR_SRV_PORT) $(SWGR_SPEC_FILE)


### PR DESCRIPTION
Previously, `make swagger.serve` will trigger `make swagger.generate`. We separate `generate` from `serve` so that it is possible to serve the manually edited swagger file.