### PR TITLE
Chore(makefile)/use standalone binary docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Golang, Gin, gRPC, MariaDB, GORM, Cobra, Pflag, Viper, Docker, GNU Make
 
 1. Check prerequisites
   - [Docker 20.10+](https://docs.docker.com/get-docker/)
+  - [Docker Compose](https://docs.docker.com/compose/install/) (NOTE: we are using the one with the standalone binary `docker-compose` instead of docker's subcommand `docker compose` to be compatible with Linux)
   - [GNU make](https://www.gnu.org/software/make/)
 
 2. Check out the repository to your local machine and go to the project root directory.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Golang, Gin, gRPC, MariaDB, GORM, Cobra, Pflag, Viper, Docker, GNU Make
     cd timer_apiserver
     ```
 
-3. Build & launch with `docker compose`
+3. Build & launch with `docker-compose`
     ```sh
     make docker.compose.up
     ```

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -30,8 +30,8 @@ services:
       - 8081:8081
       - 8082:8082
     volumes:
-      - ../../config:/app/config:ro
-      - ../../log:/app/log:wo
+      - ../../config:/app/config
+      - ../../log:/app/log
     environment:
       - APISERVER_CONFIG=/app/config/config.yml
       - APISERVER_MYSQL_HOST=db

--- a/scripts/make_rules/docker.mk
+++ b/scripts/make_rules/docker.mk
@@ -9,20 +9,20 @@ DKR_IMG_TAG := $(APP_NAME):$(GIT_COMMIT)
 docker.build: 
 	@docker build -f $(DKR_FILE) --build-arg ARCH=$(DKR_ARCH) -t $(DKR_IMG_TAG) $(PROJECT_ROOT)
 
-## docker.compose.up: Bring up Timer API Server and database with docker compose
+## docker.compose.up: Bring up Timer API Server and database with docker-compose
 .PHONY: docker.compose.up
 docker.compose.up: 
 	@cp $(PROJECT_ROOT)/config/example.yml $(PROJECT_ROOT)/config/config.yml
-	@GIT_COMMIT=$(GIT_COMMIT) docker compose -f $(DKR_COMPOSE_FILE) -p $(APP_NAME) up --build --detach --force-recreate
+	@GIT_COMMIT=$(GIT_COMMIT) docker-compose -f $(DKR_COMPOSE_FILE) -p $(APP_NAME) up --build --detach --force-recreate
 	@$(MAKE) mysql.migrate.up
 
 ## docker.compose.down: Bring down containers brought up by phony docker.compose.up
 .PHONY: docker.compose.down
 docker.compose.down: 
-	@GIT_COMMIT=$(GIT_COMMIT) docker compose -f $(DKR_COMPOSE_FILE) -p $(APP_NAME) down
+	@GIT_COMMIT=$(GIT_COMMIT) docker-compose -f $(DKR_COMPOSE_FILE) -p $(APP_NAME) down
 
 ## docker.compose.logs: Show logs inside containers brought up by phony docker.compose.up
 .PHONY: docker.compose.logs
 docker.compose.logs: 
-	@GIT_COMMIT=$(GIT_COMMIT) docker compose -f $(DKR_COMPOSE_FILE) -p $(APP_NAME) logs -f
+	@GIT_COMMIT=$(GIT_COMMIT) docker-compose -f $(DKR_COMPOSE_FILE) -p $(APP_NAME) logs -f
 


### PR DESCRIPTION
Docker's subcommand `docker compose` is found to be too new to be compatible with Linux. We replaced it with the old standalone binary `docker-compose`.

Reference: [Difference between "docker compose" and "docker-compose"](https://stackoverflow.com/a/66516826/12023612)