### PR TITLE
Ci(docker)/pass arch to docker compose

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -2,10 +2,10 @@ FROM golang:1.17.1-bullseye AS build
 
 COPY . /app
 WORKDIR /app
-ARG OS=linux
-ARG ARCH=arm64
-RUN make build PLATFORM=${OS}_${ARCH} && \
-    mv /app/_output/build/${OS}/${ARCH}/apiserver /app/apiserver
+ARG ARCH=amd64
+
+RUN make build PLATFORM=linux_${ARCH} && \
+    mv /app/_output/build/linux/${ARCH}/apiserver /app/apiserver
 
 FROM alpine:latest
 COPY --from=build /app/apiserver /app/apiserver

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     build:
       context: ../..
       dockerfile: build/docker/Dockerfile
+      args:
+        ARCH: ${GOARCH}
     image: "timer_apiserver:${GIT_COMMIT}"
     restart: always
     networks:

--- a/scripts/make_rules/docker.mk
+++ b/scripts/make_rules/docker.mk
@@ -13,7 +13,7 @@ docker.build:
 .PHONY: docker.compose.up
 docker.compose.up: 
 	@cp $(PROJECT_ROOT)/config/example.yml $(PROJECT_ROOT)/config/config.yml
-	@GIT_COMMIT=$(GIT_COMMIT) docker-compose -f $(DKR_COMPOSE_FILE) -p $(APP_NAME) up --build --detach --force-recreate
+	@GIT_COMMIT=$(GIT_COMMIT) GOARCH=$(GOARCH) docker-compose -f $(DKR_COMPOSE_FILE) -p $(APP_NAME) up --build --detach --force-recreate
 	@$(MAKE) mysql.migrate.up
 
 ## docker.compose.down: Bring down containers brought up by phony docker.compose.up


### PR DESCRIPTION
This PR resolved a bug where the image of the app built by `docker-compose` on `amd64` platform failed to run. The cause is that the correct ARCH is NOT passed to Dockerfile when building with `docker-compose` and the default ARCH was `arm64`.